### PR TITLE
Add installation docu into README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build/
 __pycache__
 .idea/*
-test*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,105 @@
-build/
-__pycache__
 .idea/*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ install:
 
 
 script:
-  - python pipeline_crab.py
+  - python tests/test_imports.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,14 @@ install:
   - git clone https://github.com/calispac/ctapipe-extra
   - pip install -e ctapipe-extra
 
-  - git clone https://github.com/calispac/digicamviewer
-  - pip install -e digicamviewer
-
   - git clone https://github.com/cocov/CTS
   - pip install -e CTS
 
-  - cd
-  - ls -larth
-  - pip install -e .
+  - git clone https://github.com/calispac/digicamviewer
+  - pip install -e digicamviewer
 
+  - git clone https://github.com/calispac/digicampipe
+  - pip install -e digicampipe
 
 script:
-  - python tests/test_imports.py
+  - python digicampipe/tests/test_imports.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: python
+python:
+  - "3.5"
+install:
+  - sudo apt-get update
+  - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
+  - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -n digicampipe python=3.5
+  - source activate digicampipe
+
+  - conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
+  - conda install matplotlib llvmlite hdf5 ipython h5py
+
+  - mkdir ctasoft
+  - cd ctasoft
+
+  - wget www.isdc.unige.ch/~lyard/repo/ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
+  - pip install ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
+  - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/python3.5/site-packages:$LD_LIBRARY_PATH
+
+  - git clone https://github.com/cta-observatory/pyhessio
+  - pip install -e pyhessio
+
+  - git clone https://github.com/calispac/ctapipe
+  - pip install -e ctapipe
+
+  - git clone https://github.com/calispac/ctapipe-extra
+  - pip install -e ctapipe-extra
+
+  - git clone https://github.com/calispac/digicamviewer
+  - pip install -e digicamviewer
+
+  - git clone https://github.com/calispac/digicampipe
+  - pip install -e digicampipe
+
+  - git clone https://github.com/cocov/CTS
+  - pip install -e CTS
+
+script:
+  - ipython digicampipe/pipeline_crab.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 install:
   - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash ./miniconda -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - sudo apt-get update
   - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
   - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - export PATH="$HOME/anaconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ install:
 
 script:
   - python digicampipe/tests/test_imports.py
+  - date
+  - python digicampipe/pipeline_crab.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash ./miniconda -b -p $HOME/miniconda
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.5"
 install:
   - sudo apt-get update
+  - sudo apt-get install libzmq3 libzmq3-dev
   - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
   - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
   - export PATH="$HOME/anaconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 install:
   - sudo apt-get update
-  - sudo apt-get install libzmq3 libzmq3-dev
+  # - sudo apt-get install libzmq3 libzmq3-dev
   - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
   - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
   - export PATH="$HOME/anaconda/bin:$PATH"
@@ -16,7 +16,7 @@ install:
   - source activate digicampipe
 
   - conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
-  - conda install matplotlib llvmlite hdf5 ipython h5py
+  - conda install matplotlib llvmlite hdf5 ipython h5py zeromq
 
   - mkdir ctasoft
   - cd ctasoft

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ install:
 
   - cd ..
   - pip install -e .
-  - pwd
-  - ls -larth
 script:
   - python tests/test_imports.py
   # - python pipeline_crab.py   ## this needs input files, commented out until test files ready

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
   - git clone https://github.com/cocov/CTS
   - pip install -e CTS
 
-install:
   - pip install -e .
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ install:
   # - conda install zeromq  ## this does not work, it installs libzmq.so.4 not libzmq.so.3 which is needed
   - sudo apt-get install libzmq3 libzmq3-dev
 
-  - echo "-----------------------"
-  - pwd
-  - ls -larth
-  - echo "-----------------------"
   - mkdir ctasoft
   - cd ctasoft
 
@@ -45,9 +41,11 @@ install:
   - git clone https://github.com/calispac/digicamviewer
   - pip install -e digicamviewer
 
-  - git clone https://github.com/calispac/digicampipe
-  - pip install -e digicampipe
-
+  - cd ..
+  - pip install -e .
+  - pwd
+  - ls -larth
 script:
-  - python digicampipe/pipeline_crab.py
+  - python tests/test_imports.py
+  - python pipeline_crab.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,12 @@ install:
   - git clone https://github.com/calispac/digicamviewer
   - pip install -e digicamviewer
 
-  - git clone https://github.com/calispac/digicampipe
-  - pip install -e digicampipe
-
   - git clone https://github.com/cocov/CTS
   - pip install -e CTS
 
+install:
+  - pip install -e .
+
+
 script:
-  - ipython digicampipe/pipeline_crab.py
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 install:
   - sudo apt-get update
-  - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash ./miniconda -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ install:
 
 
 script:
-  - python setup.py test
+  - python pipeline_crab.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ install:
   - ls -larth
 script:
   - python tests/test_imports.py
-  - python pipeline_crab.py
+  # - python pipeline_crab.py   ## this needs input files, commented out until test files ready
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ install:
   - git clone https://github.com/cocov/CTS
   - pip install -e CTS
 
+  - cd
+  - ls -larth
   - pip install -e .
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.5"
 install:
   - sudo apt-get update
-  # - sudo apt-get install libzmq3 libzmq3-dev
   - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
   - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
   - export PATH="$HOME/anaconda/bin:$PATH"
@@ -16,7 +15,9 @@ install:
   - source activate digicampipe
 
   - conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
-  - conda install matplotlib llvmlite hdf5 ipython h5py zeromq
+  - conda install matplotlib llvmlite hdf5 ipython h5py
+  # - conda install zeromq  ## this does not work, it installs libzmq.so.4 not libzmq.so.3 which is needed
+  - sudo apt-get install libzmq3 libzmq3-dev
 
   - mkdir ctasoft
   - cd ctasoft
@@ -44,6 +45,10 @@ install:
   - pip install -e digicampipe
 
 script:
+  - pwd
+  - ls -larth
+  - ls digicampipe
+
   - python digicampipe/tests/test_imports.py
   - date
   - python digicampipe/pipeline_crab.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 install:
   - sudo apt-get update
   - wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
-  - bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh -b -p $HOME/anaconda
-  - export PATH="$HOME/anaconda/bin:$PATH"
+  - bash ./miniconda -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
@@ -19,6 +19,10 @@ install:
   # - conda install zeromq  ## this does not work, it installs libzmq.so.4 not libzmq.so.3 which is needed
   - sudo apt-get install libzmq3 libzmq3-dev
 
+  - echo "-----------------------"
+  - pwd
+  - ls -larth
+  - echo "-----------------------"
   - mkdir ctasoft
   - cd ctasoft
 
@@ -45,11 +49,5 @@ install:
   - pip install -e digicampipe
 
 script:
-  - pwd
-  - ls -larth
-  - ls digicampipe
-
-  - python digicampipe/tests/test_imports.py
-  - date
   - python digicampipe/pipeline_crab.py
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ This step involves a bit of manual work, but we are working on streamlining it.
     git clone https://github.com/calispac/ctapipe-extra
     pip install -e ctapipe-extra
 
+    git clone https://github.com/cocov/CTS
+    pip install -e CTS
+
     git clone https://github.com/calispac/digicamviewer
     pip install -e digicamviewer
 
     git clone https://github.com/calispac/digicampipe
     pip install -e digicampipe
-
-    git clone https://github.com/cocov/CTS
-    pip install -e CTS
 
 
 You can only run the software, if you have access to example input data. You have to ask somebody for this.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We propose to use the most recent version.
 ## install necessary libraries and packages for CTA software
 
     conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
-    conda install matplotlib llvmlite hdf5 ipython
+    conda install matplotlib llvmlite hdf5 ipython h5py
 
 ## Prepare a folder
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
 # digicampipe
 DigiCam pipeline based on ctapipe
+
+# Installation
+
+## Anaconda
+
+Follow [the anaconda installation instructions](https://conda.io/docs/user-guide/install/linux.html).
+We propose to use the most recent version.
+
+    wget https://repo.continuum.io/archive/Anaconda3-5.0.0.1-Linux-x86_64.sh
+    bash ./Anaconda3-5.0.0.1-Linux-x86_64.sh
+
+## Create a virtual environment
+
+    conda create -n digicampipe python=3.5
+    source activate digicampipe
+
+## install necessary libraries and packages for CTA software
+
+    conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
+    conda install matplotlib llvmlite hdf5 ipython
+
+## Prepare a folder
+
+    mkdir ctasoft
+    cd ctasoft
+
+## Get ProtoZFitsReader
+
+This step involves a bit of manual work, but we are working on streamlining it.
+
+    wget www.isdc.unige.ch/~lyard/repo/ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
+    pip install ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
+
+type
+
+    python -m site
+
+you'll get something similar to this:
+
+    (digicampipe) dneise@lair:~/ctasoft$ python -m site
+    sys.path = [
+        '/home/dneise/ctasoft',
+        '/home/dneise/anaconda36/envs/digicampipe/lib/python35.zip',
+        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5',
+        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/plat-linux',
+        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/lib-dynload',
+        '/home/dneise/.local/lib/python3.5/site-packages',
+        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/site-packages',    <----- your envs site-packages
+    ]
+    USER_BASE: '/home/dneise/.local' (exists)
+    USER_SITE: '/home/dneise/.local/lib/python3.5/site-packages' (exists)
+    ENABLE_USER_SITE: True
+
+Note the `site-packages` folder of your environment. Add this folder to your LD_LIBRARY_PATH:
+
+    export LD_LIBRARY_PATH=$HOME/anaconda36/envs/digicampipe/lib/python3.5/site-packages:$LD_LIBRARY_PATH
+
+
+## Get a bunch of repos (and install in "editable" mode)
+
+    git clone https://github.com/cta-observatory/pyhessio
+    pip install -e pyhessio
+
+    git clone https://github.com/calispac/ctapipe
+    pip install -e ctapipe
+
+    git clone https://github.com/calispac/ctapipe-extra
+    pip install -e ctapipe-extra
+
+    git clone https://github.com/calispac/digicamviewer
+    pip install -e digicamviewer
+
+    git clone https://github.com/calispac/digicampipe
+    pip install -e digicampipe
+
+
+You can only run the software, if you have access to example input data. You have to ask somebody for this.
+
+    ipython digicampipe/pipeline_crab.py

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ DigiCam pipeline based on ctapipe
 
 # Installation
 
+## zerom-mq
+
+    sudo apt-get install libzmq3 libzmq3-dev
+
 ## Anaconda
 
 Follow [the anaconda installation instructions](https://conda.io/docs/user-guide/install/linux.html).

--- a/README.md
+++ b/README.md
@@ -32,30 +32,7 @@ This step involves a bit of manual work, but we are working on streamlining it.
 
     wget www.isdc.unige.ch/~lyard/repo/ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
     pip install ProtoZFitsReader-0.41.Python3.5.Linux.x86_64.tar.gz
-
-type
-
-    python -m site
-
-you'll get something similar to this:
-
-    (digicampipe) dneise@lair:~/ctasoft$ python -m site
-    sys.path = [
-        '/home/dneise/ctasoft',
-        '/home/dneise/anaconda36/envs/digicampipe/lib/python35.zip',
-        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5',
-        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/plat-linux',
-        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/lib-dynload',
-        '/home/dneise/.local/lib/python3.5/site-packages',
-        '/home/dneise/anaconda36/envs/digicampipe/lib/python3.5/site-packages',    <----- your envs site-packages
-    ]
-    USER_BASE: '/home/dneise/.local' (exists)
-    USER_SITE: '/home/dneise/.local/lib/python3.5/site-packages' (exists)
-    ENABLE_USER_SITE: True
-
-Note the `site-packages` folder of your environment. Add this folder to your LD_LIBRARY_PATH:
-
-    export LD_LIBRARY_PATH=$HOME/anaconda36/envs/digicampipe/lib/python3.5/site-packages:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/python3.5/site-packages:$LD_LIBRARY_PATH
 
 
 ## Get a bunch of repos (and install in "editable" mode)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ This step involves a bit of manual work, but we are working on streamlining it.
     git clone https://github.com/calispac/digicampipe
     pip install -e digicampipe
 
+    git clone https://github.com/cocov/CTS
+    pip install -e CTS
+
 
 You can only run the software, if you have access to example input data. You have to ask somebody for this.
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,17 @@ from setuptools import setup
 
 setup(
     name='digicampipe',
-    version='0.1.0',
-    packages=['digicampipe', 'digicampipe.io', 'digicampipe.calib', 'digicampipe.calib.camera', 'digicampipe.utils', 'digicampipe.visualization', 'digicampipe.image', 'digicampipe.instrument'],
+    version='0.1.1',
+    packages=[
+        'digicampipe',
+        'digicampipe.io',
+        'digicampipe.calib',
+        'digicampipe.calib.camera',
+        'digicampipe.utils',
+        'digicampipe.visualization',
+        'digicampipe.image',
+        'digicampipe.instrument'
+    ],
     url='https://github.com/calispac/digicampipe',
     license='GNU GPL 3.0',
     author='Cyril Alispach',

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,12 @@ setup(
     author_email='cyril.alispach@gmail.com',
     long_description=open('README.md').read(),
     description='A package for DigiCam pipeline',
-    requires=['numpy', 'matplotlib', 'scipy', 'ctapipe', 'astropy'],
+    requires=[
+        'numpy',
+        'matplotlib',
+        'scipy',
+        'ctapipe',
+        'astropy',
+        'h5py',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(
@@ -11,12 +11,13 @@ setup(
     author_email='cyril.alispach@gmail.com',
     long_description=open('README.md').read(),
     description='A package for DigiCam pipeline',
-    requires=[
+    install_requires=[
         'numpy',
         'matplotlib',
         'scipy',
-        'ctapipe',
         'astropy',
         'h5py',
     ],
+    tests_require=['pytest>=3.0.0'],
+    setup_requires=['pytest-runner'],
 )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,11 @@
+# This just checks if all imports from pipeline_crab.py work
+
+from digicampipe.calib.camera import filter, r1, random_triggers, dl0, dl2, dl1
+from digicampipe.io.event_stream import event_stream
+from digicampipe.utils import geometry
+from cts_core.camera import Camera
+from digicampipe.io.save_hillas import save_hillas_parameters_in_text, save_hillas_parameters
+from digicamviewer.viewer import EventViewer
+from digicampipe.utils import utils
+
+


### PR DESCRIPTION
This PR replaces #23. #23 came from a fork, which was unwieldy for me to work with.

The README is based on two PDFs I got and comments from @Etienne12345 and @calispac.

I made some adjustments, to streamline a bit:

1. use $CONDA_PREFIX for the LD_LIBRARY_PATH
2. I added `ipython` to the list of packages to be installed. It is just good.
3. I propose to make the ctasoft folder early and cd into is, so everything is in the same folder
4. I propose to install all packages in "editable" mode, so one can edit them in place and see the effect without the need to uninstall-reinstall. (This does not work with C/C++-extensions afaik, they need to be recompiled)

Please have a look.

---- 
Test:
   It works like this on my machine.

Travis ongoing...
