### PR TITLE
converge travis installation an README.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ install:
 
   - conda install protobuf=3.0.0 numpy six scipy astropy ipython_genutils decorator
   - conda install matplotlib llvmlite hdf5 ipython h5py
-  # - conda install zeromq  ## this does not work, it installs libzmq.so.4 not libzmq.so.3 which is needed
-  # libzmq now already in the protozfits package
-  #- sudo apt-get install libzmq3 libzmq3-dev
 
   - mkdir ctasoft
   - cd ctasoft
-  
+
   - wget http://www.isdc.unige.ch/~lyard/repo/ProtoZFitsReader-0.42.Python3.5.Linux.x86_64.tar.gz
   - pip install ProtoZFitsReader-0.42.Python3.5.Linux.x86_64.tar.gz
   - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/python3.5/site-packages:$LD_LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ DigiCam pipeline based on ctapipe
 
 # Installation
 
-## zerom-mq
-
-    sudo apt-get install libzmq3 libzmq3-dev
-
 ## Anaconda
 
 Follow [the anaconda installation instructions](https://conda.io/docs/user-guide/install/linux.html).


### PR DESCRIPTION
libzmq.so.3 is now delivered inside the ProtoZFitsReader.tar.gz
So there is no need to let the user install it.

This was commented out in the travis.yml but not removed from the README.

This PR tries to fix #31 