### PR TITLE
avoid using private forks of ctapipe and ctapipe-extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
   - mkdir ctasoft
   - cd ctasoft
-  
+
   - wget http://www.isdc.unige.ch/~lyard/repo/ProtoZFitsReader-0.42.Python3.5.Linux.x86_64.tar.gz
   - pip install ProtoZFitsReader-0.42.Python3.5.Linux.x86_64.tar.gz
   - export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/python3.5/site-packages:$LD_LIBRARY_PATH
@@ -30,10 +30,16 @@ install:
   - git clone https://github.com/cta-observatory/pyhessio
   - pip install -e pyhessio
 
-  - git clone https://github.com/calispac/ctapipe
+  - https://github.com/cta-observatory/ctapipe
+  - cd ctapipe
+  - git checkout  fe9d87e
+  - cd ..
   - pip install -e ctapipe
 
-  - git clone https://github.com/calispac/ctapipe-extra
+  - git clone https://github.com/cta-observatory/ctapipe-extra
+  - cd ctapipe-extra
+  - git checkout  6d32ca1
+  - cd ..
   - pip install -e ctapipe-extra
 
   - git clone https://github.com/cocov/CTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - git clone https://github.com/cta-observatory/pyhessio
   - pip install -e pyhessio
 
-  - https://github.com/cta-observatory/ctapipe
+  - git clone https://github.com/cta-observatory/ctapipe
   - cd ctapipe
   - git checkout  fe9d87e
   - cd ..

--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ This step involves a bit of manual work, but we are working on streamlining it.
     git clone https://github.com/cta-observatory/pyhessio
     pip install -e pyhessio
 
-    git clone https://github.com/calispac/ctapipe
+    https://github.com/cta-observatory/ctapipe
+    cd ctapipe
+    git checkout  fe9d87e
+    cd ..
     pip install -e ctapipe
 
-    git clone https://github.com/calispac/ctapipe-extra
+    git clone https://github.com/cta-observatory/ctapipe-extra
+    cd ctapipe-extra
+    git checkout  6d32ca1
+    cd ..
     pip install -e ctapipe-extra
 
     git clone https://github.com/cocov/CTS

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This step involves a bit of manual work, but we are working on streamlining it.
     git clone https://github.com/cta-observatory/pyhessio
     pip install -e pyhessio
 
-    https://github.com/cta-observatory/ctapipe
+    git clone https://github.com/cta-observatory/ctapipe
     cd ctapipe
     git checkout  fe9d87e
     cd ..


### PR DESCRIPTION
This tries to fix: #34 

by replacing the forks, by their specific commits we clearly state
that we need these specific commits for digicampipe to work.

However we also clearly state, that we did not add anything to these
projects, we just froze them in time.

This is basically handled by version numbers, but ctapipe seems to
publish not too often.