### PR TITLE
Protozfitsreader v0.43.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/dneise/protozfitsreader/archive/v0.41.1.tar.gz
+https://github.com/dneise/protozfitsreader/archive/v0.43.1.tar.gz
 -e git+https://github.com/cta-observatory/pyhessio.git#egg=pyhessio
 -e git+https://github.com/cta-observatory/ctapipe.git#egg=ctapipe
 -e git+https://github.com/cta-observatory/ctapipe-extra.git#egg=ctapipe-extra

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='digicampipe',
-    version='0.1.2',
+    version='0.1.3',
     packages=[
         'digicampipe',
         'digicampipe.io',


### PR DESCRIPTION
I am Happy to tell you that @Etienne12345 made it!
protozfitsbuffer v0.43 which he provided few days ago is nicely Py3.5 and Py3.6 compliant.

The little python package I built around it has a little test suite, which runs for Py3.5 and Py3.6 

Please have a look all the tests here:

https://github.com/dneise/protozfitsreader/blob/master/protozfitsreader/tests/test_rawzfitsreader.py

And look if the `rawzfitsreader` is really supposed to behave, the way I wrote the tests. The most tests do not help, if they test the wrong stuff.

Also please tell me if I forgot tests.

-----

In protozfitsreader v0.41 we said "protobuf=3.0.0" is a strict dependency. But protobuf 3.0.0 cannot be installed with conda for Py3.6. 

Due to the tests in v0.43 I was feeling brave enough to drop the "protobuf=3.0.0" dependency, and what should I say? The tests also pass for a newer version of protobuf.

Hence, it might be possible that also digicampipe can run with Py3.6 now.

----

I had the impression, that some problems of people resulted in old versions of protozfitsbuffer being somewhere on the disk and the linker finding these versions by chance ... 

So I included into the test script of travis the **uninstallation** of the package. 
It shows that indeed `pip uninstall protozfitsreader` removes the files. So there is at least a chance that people can install and deinstall this package.

-----

### Conclusion:

It seems possible to me, that digicampipe can be installed even without an environment directly into the root anaconda environment on modern PCs, since it can be completely removed. 