### PR TITLE
Lid ccd cones image test

### DIFF
--- a/digicampipe/fit_cones_position.py
+++ b/digicampipe/fit_cones_position.py
@@ -1,8 +1,18 @@
-from digicampipe.image.cones_image import ConesImage
+from digicampipe.image.cones_image import ConesImage, cones_simu
 
 
 def get_cone_position_simu(output_dir=None):
-    cones_img = ConesImage('test', output_dir=output_dir)
+    test_image, true_positions = cones_simu(
+        offset=(-4.3, -2.1),
+        angle_deg=10,
+        pixel_radius=35,
+        output_dir=output_dir,
+    )
+    cones_img = ConesImage(
+        test_image,
+        pixels_pos_true=true_positions,
+        output_dir=output_dir,
+    )
     cones_img.plot_cones(output_dir=output_dir)
     cones_img.plot_fft_cones(output_dir=output_dir)
     cones_img.get_cones_separation_reciprocal(output_dir=output_dir)

--- a/digicampipe/fit_cones_position.py
+++ b/digicampipe/fit_cones_position.py
@@ -10,7 +10,6 @@ def get_cone_position_simu(output_dir=None):
     )
     cones_img = ConesImage(
         test_image,
-        pixels_pos_true=true_positions,
         output_dir=output_dir,
     )
     cones_img.plot_cones(output_dir=output_dir)
@@ -27,7 +26,7 @@ def get_cone_position_simu(output_dir=None):
     cones_img.fit_camera_geometry()
     cones_img.refine_camera_geometry()
     cones_img.plot_camera_geometry(output_dir=output_dir)
-    return cones_img.pixels_pos_predict, cones_img.pixels_pos_true
+    return cones_img.pixels_pos_predict, true_positions
 
 
 def get_cones_position(filename, output_dir=None):

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -713,5 +713,5 @@ def get_pixel_nvs(digicam_config_file=camera_config_file):
     pixels_nvs = np.linalg.pinv(index_to_pos).dot(relative_pos)
     #self.pixels_nvs -= np.round(np.mean(self.pixels_nvs, axis=1)).reshape(2, 1)
     # self.pixels_nvs = np.round(self.pixels_nvs).astype(int)
-    pixels_nvs -= np.mean(self.pixels_nvs, axis=1).reshape(2, 1)
+    pixels_nvs -= np.mean(pixels_nvs, axis=1).reshape(2, 1)
     return pixels_nvs

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -642,7 +642,6 @@ class ConesImage(object):
         plt.close(fig)
         print(output_filename, 'saved.')
 
-<<<<<<< HEAD
 
 def simu_match(cones_image, true_positions, std_error_max_px=0.5):
     if cones_image.pixels_pos_predict is None:
@@ -652,26 +651,7 @@ def simu_match(cones_image, true_positions, std_error_max_px=0.5):
     offsets = []
     for i in range(3):
         angle = i * 2 / 3 * np.pi
-=======
-    def simu_match(self, std_error_max_px=0.5):
-        if self.pixels_pos_true is None:
-            raise decimal.InvalidOperation('simu_match() can only be called from simulated cones.')
-        if self.pixels_pos_predict is None:
-            self.fit_camera_geometry()
-        # as camera is invariant by 60 deg rotation, we try the 3 possibilities:
-        diffs = []
-        offsets = []
-        for i in range(3):
-            angle = i * 2 / 3 * np.pi
-            R = np.array([[np.cos(angle), np.sin(angle)], [-np.sin(angle), np.cos(angle)]])
-            pos_predict = R.dot(self.pixels_pos_predict - self.center_fitted.reshape(2, 1)) + \
-                          self.center_fitted.reshape(2, 1)
-            diffs.append(np.std(pos_predict - self.pixels_pos_true))
-            offsets.append(np.mean(pos_predict - self.pixels_pos_true, axis=1))
-        print('error on pixel position: ', np.min(diffs))
-        print('offset=', offsets[np.argmin(diffs)])
-        angle = np.argmin(diffs) * 2 / 3 * np.pi
->>>>>>> lid_ccd
+
         R = np.array([[np.cos(angle), np.sin(angle)], [-np.sin(angle), np.cos(angle)]])
         pos_predict = R.dot(cones_image.pixels_pos_predict - cones_image.center_fitted.reshape(2, 1)) + \
                       cones_image.center_fitted.reshape(2, 1)

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -655,7 +655,7 @@ class ConesImage(object):
         return np.std(self.pixels_pos_predict - self.pixels_pos_true) < std_error_max_px
 
 
-def cones_simu(pixels_nvs, offset=(0,0), angle_deg=0, image_shape=(2472, 3296), pixel_radius=38.3,
+def cones_simu(pixels_nvs=None, offset=(0,0), angle_deg=0, image_shape=(2472, 3296), pixel_radius=38.3,
                noise_ampl=0., output_dir=None):
     """
     function to create a test cones image according to given parameters
@@ -667,6 +667,8 @@ def cones_simu(pixels_nvs, offset=(0,0), angle_deg=0, image_shape=(2472, 3296), 
     :param output_dir: optional directory where to put the original lid CCD image
     :return:
     """
+    if pixels_nvs is None:
+        pixels_nvs = get_pixel_nvs()
     angle_rot = angle_deg / 180 * np.pi
     offset = np.array(offset)
     image = np.zeros(image_shape)

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -11,7 +11,9 @@ import os
 
 class ConesImage(object):
     def __init__(self, image, image_cone=None, output_dir=None,
-                 digicam_config_file='./tests/resources/camera_config.cfg'):
+                 digicam_config_file='./tests/resources/camera_config.cfg',
+                 pixels_pos_true=None
+                 ):
         """
         constructor of a ConesImage object.
         :param image: fit filename or numpy array containing the lid CCD image.
@@ -34,12 +36,11 @@ class ConesImage(object):
         #self.pixels_nvs -= np.round(np.mean(self.pixels_nvs, axis=1)).reshape(2, 1)
         # self.pixels_nvs = np.round(self.pixels_nvs).astype(int)
         self.pixels_nvs -= np.mean(self.pixels_nvs, axis=1).reshape(2, 1)
-        self.pixels_pos_true = None  # true position of pixels only know in the simu case
+        self.pixels_pos_true = pixels_pos_true  # true position of pixels only know in the simu case
         if type(image) is str:
             if image == 'test':
-                image = cones_simu(
+                image, self.pixels_pos_true = cones_simu(
                     self.pixels_nvs,
-                    self.pixels_pos_true,
                     offset=(-4.3, -2.1),
                     angle_deg=10,
                     pixel_radius=35,
@@ -666,7 +667,7 @@ class ConesImage(object):
         return np.std(self.pixels_pos_predict - self.pixels_pos_true) < std_error_max_px
 
 
-def cones_simu(pixels_nvs, pixels_pos_true, offset=(0,0), angle_deg=0, image_shape=(2472, 3296), pixel_radius=38.3,
+def cones_simu(pixels_nvs, offset=(0,0), angle_deg=0, image_shape=(2472, 3296), pixel_radius=38.3,
                noise_ampl=0., output_dir=None):
     """
     function to create a test cones image according to given parameters
@@ -711,4 +712,4 @@ def cones_simu(pixels_nvs, pixels_pos_true, offset=(0,0), angle_deg=0, image_sha
         plt.savefig(output_filename, bbox_inches='tight', pad_inches=0)
         plt.close(fig)
         print(output_filename, 'saved.')
-    return image
+    return image, pixels_pos_true

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -37,7 +37,14 @@ class ConesImage(object):
         self.pixels_pos_true = None  # true position of pixels only know in the simu case
         if type(image) is str:
             if image == 'test':
-                image = self.cones_simu(offset=(-4.3, -2.1), angle_deg=10, pixel_radius=35, output_dir=output_dir)
+                image = cones_simu(
+                    self.pixels_nvs,
+                    self.pixels_pos_true,
+                    offset=(-4.3, -2.1),
+                    angle_deg=10,
+                    pixel_radius=35,
+                    output_dir=output_dir,
+                )
             else:
                 self.filename = image
                 image = fits.open(image)[0].data

--- a/digicampipe/image/cones_image.py
+++ b/digicampipe/image/cones_image.py
@@ -1,3 +1,4 @@
+from pkg_resources import resource_filename
 from digicampipe.utils import geometry
 from digicampipe.image.kernels import *
 from digicampipe.image.utils import *
@@ -8,16 +9,19 @@ import numpy as np
 from decimal import *
 import os
 
+camera_config_file = resource_filename(
+    'digicampipe',
+    'tests/resources/camera_config.cfg')
+
 
 class ConesImage(object):
     def __init__(self, image, image_cone=None, output_dir=None,
-                 digicam_config_file='./tests/resources/camera_config.cfg',
+                 digicam_config_file=camera_config_file,
                  pixels_pos_true=None
                  ):
         """
         constructor of a ConesImage object.
         :param image: fit filename or numpy array containing the lid CCD image.
-        If set to 'test', a test image is created.
         :param image_cone: optional fit filename of the cone image. the fit file is created calling get_cone()
         :param output_dir: optional directory where to put the original lid CCD image in case of test
         :param digicam_config_file: path to the digicam configuration file
@@ -26,17 +30,8 @@ class ConesImage(object):
         self.pixels_nvs = get_pixel_nvs(digicam_config_file)
         self.pixels_pos_true = pixels_pos_true  # true position of pixels only know in the simu case
         if type(image) is str:
-            if image == 'test':
-                image, self.pixels_pos_true = cones_simu(
-                    self.pixels_nvs,
-                    offset=(-4.3, -2.1),
-                    angle_deg=10,
-                    pixel_radius=35,
-                    output_dir=output_dir,
-                )
-            else:
-                self.filename = image
-                image = fits.open(image)[0].data
+            self.filename = image
+            image = fits.open(image)[0].data
         if type(image) is not np.ndarray:
             raise AttributeError('image must be a filename or a numpy.ndarray')
         # high pass filter
@@ -705,7 +700,7 @@ def cones_simu(pixels_nvs=None, offset=(0,0), angle_deg=0, image_shape=(2472, 32
     return image, pixels_pos_true
 
 
-def get_pixel_nvs(digicam_config_file='./tests/resources/camera_config.cfg'):
+def get_pixel_nvs(digicam_config_file=camera_config_file):
     # Camera and Geometry objects (mapping, pixel, patch + x,y coordinates pixels)
     digicam = Camera(_config_file=digicam_config_file)
     digicam_geometry = geometry.generate_geometry_from_camera(camera=digicam)

--- a/digicampipe/tests/test_lid_ccd.py
+++ b/digicampipe/tests/test_lid_ccd.py
@@ -1,5 +1,5 @@
 from digicampipe.image.sky_image import LidCCDObservation
-from digicampipe.image.cones_image import ConesImage
+from digicampipe.image.cones_image import ConesImage, cones_simu
 
 from pkg_resources import resource_filename
 from glob import glob
@@ -37,12 +37,14 @@ def test_find_stars():
     assert nsolved > 0
 
 
-camera_config_file = resource_filename('digicampipe', 'tests/resources/camera_config.cfg')
-
-
 def test_cone_simu():
+    test_image, true_positions = cones_simu(
+        offset=(-4.3, -2.1),
+        angle_deg=10,
+        pixel_radius=35,
+    )
     # create an image  with a geometry compatible to the camera with known angle, spacing between pixels etc...
-    cones_img = ConesImage('test',digicam_config_file=camera_config_file)
+    cones_img = ConesImage(test_image, pixels_pos_true=true_positions)
     cones_img.get_cone(radius_mask=2.1, save_to_file=False)
     cones_img.fit_camera_geometry()
     cones_img.refine_camera_geometry()

--- a/digicampipe/tests/test_lid_ccd.py
+++ b/digicampipe/tests/test_lid_ccd.py
@@ -1,6 +1,3 @@
-from digicampipe.image.sky_image import LidCCDObservation
-from digicampipe.image.cones_image import ConesImage, cones_simu
-
 from pkg_resources import resource_filename
 from glob import glob
 
@@ -10,6 +7,7 @@ example_lid_CCD_image_file_paths = glob(
 
 
 def test_find_stars():
+    from digicampipe.image.sky_image import LidCCDObservation
     # find stars in lid CCD images:
     crop_pixels1 = [  # (850, 50),
         # (550, 500),
@@ -38,6 +36,9 @@ def test_find_stars():
 
 
 def test_cone_simu():
+    from digicampipe.image.cones_image import ConesImage, cones_simu
+    from digicampipe.image.cones_image import simu_match
+
     # create an image  with a geometry compatible to the camera with
     # known angle, spacing between pixels etc...
     test_image, true_positions = cones_simu(
@@ -50,7 +51,6 @@ def test_cone_simu():
     cones_img.fit_camera_geometry()
     cones_img.refine_camera_geometry()
 
-    from digicampipe.image.cones_image import simu_match
     assert simu_match(cones_img, true_positions, std_error_max_px=0.5)
 
 

--- a/digicampipe/tests/test_lid_ccd.py
+++ b/digicampipe/tests/test_lid_ccd.py
@@ -44,11 +44,13 @@ def test_cone_simu():
         pixel_radius=35,
     )
     # create an image  with a geometry compatible to the camera with known angle, spacing between pixels etc...
-    cones_img = ConesImage(test_image, pixels_pos_true=true_positions)
+    cones_img = ConesImage(test_image)
     cones_img.get_cone(radius_mask=2.1, save_to_file=False)
     cones_img.fit_camera_geometry()
     cones_img.refine_camera_geometry()
-    assert cones_img.simu_match(std_error_max_px=0.5)
+
+    from digicampipe.image.cones_image import simu_match
+    assert simu_match(cones_img, true_positions, std_error_max_px=0.5)
 
 
 if __name__ == '__main__':

--- a/digicampipe/tests/test_lid_ccd.py
+++ b/digicampipe/tests/test_lid_ccd.py
@@ -38,12 +38,13 @@ def test_find_stars():
 
 
 def test_cone_simu():
+    # create an image  with a geometry compatible to the camera with
+    # known angle, spacing between pixels etc...
     test_image, true_positions = cones_simu(
         offset=(-4.3, -2.1),
         angle_deg=10,
         pixel_radius=35,
     )
-    # create an image  with a geometry compatible to the camera with known angle, spacing between pixels etc...
     cones_img = ConesImage(test_image)
     cones_img.get_cone(radius_mask=2.1, save_to_file=False)
     cones_img.fit_camera_geometry()


### PR DESCRIPTION
This is a proposal, how to remove the special 'test' string parameter from the ConesImage c-tor. 

I think the ConesImage c-tor should accept only an image as a parameter to its contructor. If we want to test it, we give it a test image. Of course we have to *make* the test_image before we can give it. So it looks like it is a bit more work, but I think code under test should not "know" it is under test, so it should not have dedicated `if`s which are needed for testing.

It still has a special parameter, which is the position of the `true_pixel_positions`, but I see already how to remove that ... 